### PR TITLE
Fix long video bug, avoid video quality drop, and add option for original size video

### DIFF
--- a/THP-Converter-CS-CLI/Classes/MP4Video.cs
+++ b/THP-Converter-CS-CLI/Classes/MP4Video.cs
@@ -50,7 +50,7 @@ namespace THP_Converter_CS_CLI.Classes
                 UseShellExecute = false,
                 WindowStyle = ProcessWindowStyle.Hidden,
                 FileName = "cmd.exe",
-                Arguments = $"/c ffmpeg.exe -i video.mp4 -r {Rate} -vf scale={Width}:{Height} temp\\frame%03d.jpg"
+                Arguments = $"/c ffmpeg.exe -i video.mp4 -r {Rate} -vf scale={Width}:{Height} -qscale:v 2 temp\\frame%05d.jpg"
             }).WaitForExit();
             File.Delete("ffmpeg.exe");
             if (UseAudio)
@@ -71,7 +71,7 @@ namespace THP_Converter_CS_CLI.Classes
                 UseShellExecute = false,
                 WindowStyle = ProcessWindowStyle.Hidden,
                 FileName = "cmd.exe",
-                Arguments = UseAudio ? $"/c thpconv.exe -j temp/*.jpg -r {Rate} -s temp.wav -d output.thp" : $"/c thpconv.exe -j temp/*.jpg -r {Rate} -d output.thp" 
+                Arguments = $"/c thpconv.exe -j temp/*.jpg -r {Rate}{(UseAudio ? " - s temp.wav" : "")} -d output.thp"
             }).WaitForExit();
             File.Move("output.thp", OutFile.FullName);
             Console.WriteLine($"Converted {InFile.Name} to {OutFile.Name}");

--- a/THP-Converter-CS-CLI/Classes/MP4Video.cs
+++ b/THP-Converter-CS-CLI/Classes/MP4Video.cs
@@ -71,7 +71,7 @@ namespace THP_Converter_CS_CLI.Classes
                 UseShellExecute = false,
                 WindowStyle = ProcessWindowStyle.Hidden,
                 FileName = "cmd.exe",
-                Arguments = $"/c thpconv.exe -j temp/*.jpg -r {Rate}{(UseAudio ? " - s temp.wav" : "")} -d output.thp"
+                Arguments = $"/c thpconv.exe -j temp/*.jpg -r {Rate}{(UseAudio ? " -s temp.wav" : "")} -d output.thp"
             }).WaitForExit();
             File.Move("output.thp", OutFile.FullName);
             Console.WriteLine($"Converted {InFile.Name} to {OutFile.Name}");

--- a/THP-Conveter-CS/GUI/MP4.Designer.cs
+++ b/THP-Conveter-CS/GUI/MP4.Designer.cs
@@ -40,9 +40,10 @@ namespace THP_Conveter_CS.GUI
             // 
             // button1
             // 
-            this.button1.Location = new System.Drawing.Point(126, 168);
+            this.button1.Location = new System.Drawing.Point(180, 280);
+            this.button1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(246, 110);
+            this.button1.Size = new System.Drawing.Size(351, 183);
             this.button1.TabIndex = 0;
             this.button1.Text = "Search for a mp4 file";
             this.button1.UseVisualStyleBackColor = true;
@@ -50,9 +51,10 @@ namespace THP_Conveter_CS.GUI
             // 
             // button2
             // 
-            this.button2.Location = new System.Drawing.Point(427, 168);
+            this.button2.Location = new System.Drawing.Point(610, 280);
+            this.button2.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.button2.Name = "button2";
-            this.button2.Size = new System.Drawing.Size(246, 110);
+            this.button2.Size = new System.Drawing.Size(351, 183);
             this.button2.TabIndex = 1;
             this.button2.Text = "Save the new thp file";
             this.button2.UseVisualStyleBackColor = true;
@@ -60,18 +62,20 @@ namespace THP_Conveter_CS.GUI
             // 
             // textBox1
             // 
-            this.textBox1.Location = new System.Drawing.Point(468, 114);
+            this.textBox1.Location = new System.Drawing.Point(669, 190);
+            this.textBox1.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.textBox1.Name = "textBox1";
             this.textBox1.PlaceholderText = "29.97";
-            this.textBox1.Size = new System.Drawing.Size(173, 23);
+            this.textBox1.Size = new System.Drawing.Size(245, 31);
             this.textBox1.TabIndex = 2;
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(471, 96);
+            this.label1.Location = new System.Drawing.Point(673, 160);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(170, 15);
+            this.label1.Size = new System.Drawing.Size(259, 25);
             this.label1.TabIndex = 3;
             this.label1.Text = "The frame rate of the thp video";
             // 
@@ -80,6 +84,7 @@ namespace THP_Conveter_CS.GUI
             this.VideoSizeComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.VideoSizeComboBox.FormattingEnabled = true;
             this.VideoSizeComboBox.Items.AddRange(new object[] {
+            "Original",
             "640x368",
             "336x528",
             "672x752",
@@ -93,18 +98,20 @@ namespace THP_Conveter_CS.GUI
             "256x192",
             "608x464",
             "512x192"});
-            this.VideoSizeComboBox.Location = new System.Drawing.Point(493, 70);
+            this.VideoSizeComboBox.Location = new System.Drawing.Point(704, 117);
+            this.VideoSizeComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.VideoSizeComboBox.MaxDropDownItems = 13;
             this.VideoSizeComboBox.Name = "VideoSizeComboBox";
-            this.VideoSizeComboBox.Size = new System.Drawing.Size(121, 23);
+            this.VideoSizeComboBox.Size = new System.Drawing.Size(171, 33);
             this.VideoSizeComboBox.TabIndex = 6;
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(520, 52);
+            this.label3.Location = new System.Drawing.Point(743, 87);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(60, 15);
+            this.label3.Size = new System.Drawing.Size(94, 25);
             this.label3.TabIndex = 7;
             this.label3.Text = "Video Size";
             // 
@@ -113,19 +120,20 @@ namespace THP_Conveter_CS.GUI
             this.UseAudioCheckBox.AutoSize = true;
             this.UseAudioCheckBox.Checked = true;
             this.UseAudioCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.UseAudioCheckBox.Location = new System.Drawing.Point(506, 143);
+            this.UseAudioCheckBox.Location = new System.Drawing.Point(723, 238);
+            this.UseAudioCheckBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.UseAudioCheckBox.Name = "UseAudioCheckBox";
-            this.UseAudioCheckBox.Size = new System.Drawing.Size(85, 19);
+            this.UseAudioCheckBox.Size = new System.Drawing.Size(128, 29);
             this.UseAudioCheckBox.TabIndex = 8;
             this.UseAudioCheckBox.Text = "Use Audio?";
             this.UseAudioCheckBox.UseVisualStyleBackColor = true;
             // 
             // MP4
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Control;
-            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.ClientSize = new System.Drawing.Size(1143, 750);
             this.Controls.Add(this.UseAudioCheckBox);
             this.Controls.Add(this.label3);
             this.Controls.Add(this.VideoSizeComboBox);
@@ -133,6 +141,7 @@ namespace THP_Conveter_CS.GUI
             this.Controls.Add(this.textBox1);
             this.Controls.Add(this.button2);
             this.Controls.Add(this.button1);
+            this.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.MaximizeBox = false;
             this.Name = "MP4";
             this.ShowIcon = false;

--- a/THP-Conveter-CS/GUI/MP4.Designer.cs
+++ b/THP-Conveter-CS/GUI/MP4.Designer.cs
@@ -36,6 +36,7 @@ namespace THP_Conveter_CS.GUI
             this.VideoSizeComboBox = new System.Windows.Forms.ComboBox();
             this.label3 = new System.Windows.Forms.Label();
             this.UseAudioCheckBox = new System.Windows.Forms.CheckBox();
+            this.label2 = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // button1
@@ -98,7 +99,7 @@ namespace THP_Conveter_CS.GUI
             "256x192",
             "608x464",
             "512x192"});
-            this.VideoSizeComboBox.Location = new System.Drawing.Point(704, 117);
+            this.VideoSizeComboBox.Location = new System.Drawing.Point(704, 79);
             this.VideoSizeComboBox.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
             this.VideoSizeComboBox.MaxDropDownItems = 13;
             this.VideoSizeComboBox.Name = "VideoSizeComboBox";
@@ -108,7 +109,7 @@ namespace THP_Conveter_CS.GUI
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(743, 87);
+            this.label3.Location = new System.Drawing.Point(743, 49);
             this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(94, 25);
@@ -128,12 +129,23 @@ namespace THP_Conveter_CS.GUI
             this.UseAudioCheckBox.Text = "Use Audio?";
             this.UseAudioCheckBox.UseVisualStyleBackColor = true;
             // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(541, 117);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(501, 25);
+            this.label2.TabIndex = 9;
+            this.label2.Text = "Note: If using Original, Height/Width must be multiples of 16.";
+            this.label2.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            // 
             // MP4
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Control;
             this.ClientSize = new System.Drawing.Size(1143, 750);
+            this.Controls.Add(this.label2);
             this.Controls.Add(this.UseAudioCheckBox);
             this.Controls.Add(this.label3);
             this.Controls.Add(this.VideoSizeComboBox);
@@ -160,5 +172,6 @@ namespace THP_Conveter_CS.GUI
         private System.Windows.Forms.ComboBox VideoSizeComboBox;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.CheckBox UseAudioCheckBox;
+        private System.Windows.Forms.Label label2;
     }
 }

--- a/THP-Conveter-CS/GUI/MP4.cs
+++ b/THP-Conveter-CS/GUI/MP4.cs
@@ -20,6 +20,7 @@ namespace THP_Conveter_CS.GUI
         {
             InitializeComponent();
             label1.Hide();
+            label2.Hide();
             button2.Hide();
             textBox1.Hide();
             label3.Hide();
@@ -43,6 +44,7 @@ namespace THP_Conveter_CS.GUI
                 Properties.Settings.Default.mp4_video = open.FileName;
                 Properties.Settings.Default.Save();
                 label1.Show();
+                label2.Show();
                 button2.Show();
                 textBox1.Show();
                 label3.Show();

--- a/THP-Conveter-CS/GUI/MP4.cs
+++ b/THP-Conveter-CS/GUI/MP4.cs
@@ -98,8 +98,12 @@ namespace THP_Conveter_CS.GUI
             Classes.Manager manager = new();
             manager.ExtractResource("THPConv.exe", Properties.Resources.THPConv);
             manager.ExtractResource("dsptool.dll", Properties.Resources.dsptool);
-            string width = ((string)VideoSizeComboBox.SelectedItem)[0..((string)VideoSizeComboBox.SelectedItem).IndexOf('x')],
-                height = ((string)VideoSizeComboBox.SelectedItem)[(((string)VideoSizeComboBox.SelectedItem).IndexOf('x') + 1)..];
+            string scaleParameter = "";
+            if ((string)VideoSizeComboBox.SelectedItem != "Original")
+            {
+                scaleParameter = $" -vf scale={((string)VideoSizeComboBox.SelectedItem)[0..((string)VideoSizeComboBox.SelectedItem).IndexOf('x')]}:"
+                    + ((string)VideoSizeComboBox.SelectedItem)[(((string)VideoSizeComboBox.SelectedItem).IndexOf('x') + 1)..];
+            }
             Directory.CreateDirectory("temp");
             File.Copy(inputFile, "video.mp4");
             using (Process process = new())
@@ -110,7 +114,7 @@ namespace THP_Conveter_CS.GUI
                     UseShellExecute = false,
                     WindowStyle = ProcessWindowStyle.Hidden,
                     FileName = "cmd.exe",
-                    Arguments = $"/c ffmpeg.exe -i video.mp4 -r {rate} -vf scale={width}:{height} temp\\frame%03d.jpg"
+                    Arguments = $"/c ffmpeg.exe -i video.mp4 -r {rate}{scaleParameter} -qscale:v 2 temp\\frame%05d.jpg"
                 };
                 process.StartInfo = startInfo;
                 process.Start();
@@ -135,7 +139,7 @@ namespace THP_Conveter_CS.GUI
                     UseShellExecute = false,
                     WindowStyle = ProcessWindowStyle.Hidden,
                     FileName = "cmd.exe",
-                    Arguments = UseAudioCheckBox.Checked ? $"/c thpconv.exe -j temp/*.jpg -r {rate} -s temp.wav -d output.thp" : $"/c thpconv.exe -j temp/*.jpg -r {rate} -d output.thp"
+                    Arguments = $"/c thpconv.exe -j temp/*.jpg -r {rate}{(UseAudioCheckBox.Checked ? " -s temp.wav" : "")} -d output.thp"
                 };
                 process.Start();
                 process.WaitForExit();

--- a/THP_Converter_PY/MP4toTHP.py
+++ b/THP_Converter_PY/MP4toTHP.py
@@ -12,7 +12,7 @@ def main():
         raise FileNotFoundError
     if os.path.isfile(out_file) == True:
         raise FileExistsError
-    os.system('cmd /c ffmpeg -i "'+file+'" -r '+str(rate)+' frame%03d.jpg')
+    os.system('cmd /c ffmpeg -i "'+file+'" -r '+str(rate)+' -qscale:v 2 frame%05d.jpg')
     os.system('cmd /c thpconv -j *.jpg -d "'+out_file+'"')
     os.system('cmd /c del /f *.jpg')
     print("Complete.")


### PR DESCRIPTION
Per the THPConv documentation on serial JPEG files:
>  The frame number at the end of the file name must have the same number of digits as the final frame,
with zeros attached to the front

When naming the frame images with `%03d`, videos longer than 1000 frames will end up with glitchy output from THPConv. By bumping this to `%05d`, we can support 30fps videos up to 55 minutes long (which is certainly longer than any THP will realistically be) up from 33 seconds long.

Additionally, I've added `qscale:v -2` to make the JPEG images that ffmpeg outputs higher quality which helps maintain THP quality.

Finally, I added an option to the form to preserve the original aspect ratio of the input mp4 video. This is slightly dangerous, I realize, as video height/width must be multiples of 16. Thus, I've added a note to the form to make sure the user is aware of this.